### PR TITLE
Always do name resolution

### DIFF
--- a/dolly.c
+++ b/dolly.c
@@ -594,7 +594,7 @@ static void buildring(struct dollytab * mydollytab) {
             p = info_buf;
             info_buf[ret] = 0;	
             if(mydollytab->flag_v) {
-              fprintf(stderr, info_buf);
+              fprintf(stderr, "%s", info_buf);
             }
             while((p = strstr(p, "ready")) != NULL) {
               ready_mach++;


### PR DESCRIPTION
in case of usage of an external dolly.cfg file this lead to an error on server as he can't get an dollytab->hostname.